### PR TITLE
arg0 trait fixes

### DIFF
--- a/asyncfuture.h
+++ b/asyncfuture.h
@@ -237,7 +237,7 @@ struct ret_type_is_future {
 template <typename Functor>
 struct arg0_is_future {
     enum {
-        value = future_traits<Arg0Type<Functor>>::is_future
+        value = future_traits<typename std::decay<Arg0Type<Functor>>::type>::is_future
     };
 };
 

--- a/asyncfuture.h
+++ b/asyncfuture.h
@@ -168,6 +168,16 @@ template <typename C, typename R, typename Arg0, typename ...Args>
 struct arg0_traits<R(C::*)(Arg0, Args...)> {
     typedef Arg0 type;
 };
+    
+template <typename R>
+struct arg0_traits<R()> {
+  typedef void type;
+};
+
+template <typename R, typename Arg0, typename ...Args>
+struct arg0_traits<R(Arg0, Args...)> {
+  typedef Arg0 type;
+};
 
 // Obtain the observable type according to the Functor
 template <typename T>


### PR DESCRIPTION
This modifies the `arg0_is_future` trait to allow `const QFuture<T>&` as arguments and adds a specialization for non member function to the `arg0_traits` trait.