### PR TITLE
Added QBS product for import into other builds

### DIFF
--- a/asyncfuture.qbs
+++ b/asyncfuture.qbs
@@ -1,0 +1,19 @@
+import qbs
+
+StaticLibrary {
+    name: "asyncfuture"
+
+    Depends { name: "cpp" }
+
+    cpp.includePaths: [
+        "."
+    ]
+
+    Export {
+        Depends { name: "cpp" }
+        cpp.includePaths: [
+            "."
+        ]
+    }
+
+}


### PR DESCRIPTION
Allows asyncfuture to be added to qbs project as a dependancy. 