### PR TITLE
Ability to use signal with const-ref args in observe method

### DIFF
--- a/asyncfuture.h
+++ b/asyncfuture.h
@@ -142,7 +142,7 @@ struct signal_traits<R (C::*)()> {
 
 template <typename R, typename C, typename ARG0>
 struct signal_traits<R (C::*)(ARG0)> {
-    typedef ARG0 result_type;
+    typedef typename std::decay<ARG0>::type result_type;
 };
 
 template <typename T>


### PR DESCRIPTION
The observe method is not able to work with signals with const-ref arguments. For example if you have signal with const-ref argument ```void mySignal(const QString&)``` and trying to observe it with observe method ```AsyncFuture::observe(myObj, &MyObj::mySignal)``` you will get a build error. This pull request fixes it.