### PR TITLE
Fix const-correctness for context QObjects - issue #24

### DIFF
--- a/asyncfuture.h
+++ b/asyncfuture.h
@@ -336,13 +336,13 @@ void runInMainThread(F func) {
 
 template <typename T, typename Finished, typename Canceled>
 void watch(QFuture<T> future,
-           QObject* owner,
-           QObject* contextObject,
+		   const QObject* owner,
+		   const QObject* contextObject,
            Finished finished,
            Canceled canceled) {
 
     Q_ASSERT(owner);
-    QPointer<QObject> ownerAlive = owner;
+	QPointer<const QObject> ownerAlive = owner;
 
     QFutureWatcher<T> *watcher = new QFutureWatcher<T>();
 
@@ -565,7 +565,7 @@ public:
     }
 
     template <typename Member>
-    void cancel(QObject* sender, Member member) {
+	void cancel(const QObject* sender, Member member) {
         incWeakRefCount();
         QObject::connect(sender, member,
                          this, [=]() {
@@ -1001,7 +1001,7 @@ eval(Functor functor, QFuture<T> future) {
  * e.g DeferredFuture<int> = Value<QFuture<int>>
  */
 template <typename DeferredType, typename RetType, typename T, typename Completed, typename Canceled>
-static QFuture<DeferredType> execute(QFuture<T> future, QObject* contextObject, Completed onCompleted, Canceled onCanceled) {
+static QFuture<DeferredType> execute(QFuture<T> future, const QObject* contextObject, Completed onCompleted, Canceled onCanceled) {
 
     auto defer = DeferredFuture<DeferredType>::create();
 
@@ -1060,7 +1060,7 @@ public:
     typename std::enable_if< !Private::future_traits<typename Private::function_traits<Completed>::result_type>::is_future,
     Observable<typename Private::function_traits<Completed>::result_type>
     >::type
-    context(QObject* contextObject, Completed functor)  {
+	context(const QObject* contextObject, Completed functor)  {
         /* functor return non-QFuture type */
 
         ASYNC_FUTURE_CALLBACK_STATIC_ASSERT("context(callback): ", Completed);
@@ -1074,7 +1074,7 @@ public:
     typename std::enable_if< Private::future_traits<typename Private::function_traits<Completed>::result_type>::is_future,
     Observable<typename Private::future_traits<typename Private::function_traits<Completed>::result_type>::arg_type>
     >::type
-    context(QObject* contextObject, Completed functor)  {
+	context(const QObject* contextObject, Completed functor)  {
         /* functor returns a QFuture */
 
         ASYNC_FUTURE_CALLBACK_STATIC_ASSERT("context(callback): ", Completed);
@@ -1232,7 +1232,7 @@ public:
 
 private:
     template <typename ObservableType, typename RetType, typename Completed>
-    Observable<ObservableType> _context(QObject* contextObject, Completed functor)  {
+	Observable<ObservableType> _context(const QObject* contextObject, Completed functor)  {
 
         auto future = Private::execute<ObservableType, RetType>(m_future,
                                                                contextObject,


### PR DESCRIPTION
Here's the patch I did for issue #24 .